### PR TITLE
write encrypted output to a temp file first, to prevent concurrent read and write

### DIFF
--- a/decrypt.sh
+++ b/decrypt.sh
@@ -37,7 +37,8 @@ if [ "${GPG_PRIVATE_KEY:-}" ]; then
   echo >&2 "=> Importing GPG_PRIVATE_KEY..."
   echo "$GPG_PRIVATE_KEY" | sed 's/[,]/\n/g' | gpg --import - >&2
 else
-  (set -x && gpg -qd "${here}/shared-private.gpg.secrets" | gpg -q --import -)
+  echo >&2 "=> Importing shared-private.gpg..."
+  gpg -qd "${here}/shared-private.gpg.secrets" 2> /dev/null | gpg -q --import -
 fi
 
 # TODO: consider verifying GPG signature of the last commit that changed secrets with:

--- a/decrypt.sh
+++ b/decrypt.sh
@@ -37,7 +37,7 @@ if [ "${GPG_PRIVATE_KEY:-}" ]; then
   echo >&2 "=> Importing GPG_PRIVATE_KEY..."
   echo "$GPG_PRIVATE_KEY" | sed 's/[,]/\n/g' | gpg --import - >&2
 else
-  gpg -qd "${here}/shared-private.gpg.secrets" | gpg -q --import -
+  (set -x && gpg -qd "${here}/shared-private.gpg.secrets" | gpg -q --import -)
 fi
 
 # TODO: consider verifying GPG signature of the last commit that changed secrets with:

--- a/encrypt.sh
+++ b/encrypt.sh
@@ -43,7 +43,10 @@ else
 fi
 
 echo >&2 "=> Encrypting ${input} -> ${output} with GPG..."
+# Writing to a temp file prevents a collision when the input is being piped from the file itself
+tmp_output="$(mktemp)"
 (set -x && gpg -sea --yes \
   --recipient-file "${here}"/shared-public.gpg \
   ${recipients} \
-  -o "${output}" "${input}")
+  -o - "${input}") > "${tmp_output}"
+mv "${tmp_output}" "${output}"

--- a/install-secrets.sh
+++ b/install-secrets.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ ! -d ./secrets ]; then
+  if [ "${CI:-}" ]; then
+    curl -sSL --output - https://github.com/OmnipresentGroup/secrets/archive/refs/heads/main.tar.gz | tar -xvzf -
+    move secrets-main secrets
+  else
+    if grep -q 'OmnipresentGroup/secrets' ../secrets/.git/config 2> /dev/null; then
+      echo "=> Linking ./secrets to ../secrets …"
+      (set -x && ln -s ../secrets/ secrets)
+      (cd secrets && git pull --rebase)
+    else
+      echo '=> Cloning secrets repo into ./secrets …'
+      echo '   If you have the secrets repo cloned somewhere, you can run:'
+      echo '$ ln -s {path_to_your_local_repos}/secrets/ secrets'
+      (set -x && git clone git@github.com:OmnipresentGroup/secrets.git)
+    fi
+  fi
+else
+  (cd secrets && git pull --rebase)
+fi
+
+

--- a/trusted-user-keys.txt
+++ b/trusted-user-keys.txt
@@ -5,3 +5,4 @@ https://github.com/faizanhaider.gpg
 https://github.com/LauraBeatris.gpg
 https://github.com/kiramdany.gpg
 https://github.com/Pegase745.gpg
+https://github.com/wisdomadzorgenu.gpg

--- a/trusted-user-keys.txt
+++ b/trusted-user-keys.txt
@@ -3,3 +3,5 @@ https://github.com/jpbochi.gpg
 https://github.com/mattbelanger.gpg
 https://github.com/faizanhaider.gpg
 https://github.com/LauraBeatris.gpg
+https://github.com/kiramdany.gpg
+https://github.com/Pegase745.gpg


### PR DESCRIPTION
also, update the list of trusted keys.